### PR TITLE
Add view transition support for blog titles

### DIFF
--- a/src/layouts/blog-post.astro
+++ b/src/layouts/blog-post.astro
@@ -23,7 +23,13 @@ const { frontmatter } = Astro.props;
   <main class="post">
     <article>
       <header class="post__header">
-        <h1 class="post__title">{frontmatter.title}</h1>
+        <h1 class="post__title">
+          <span
+            style={`view-transition-name: blog-title-${Astro.url.pathname.split("/").pop()}`}
+          >
+            {frontmatter.title}
+          </span>
+        </h1>
         <div class="post__meta">
           <time datetime={frontmatter.date}>
             {

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -39,6 +39,7 @@ posts.sort(
                   <a
                     href={`/blog/${post.file?.split("/").pop()?.split(".").shift() ?? ""}`}
                     class="blog__title-link"
+                    style={`view-transition-name: blog-title-${post.file?.split("/").pop()?.split(".").shift() ?? ""}`}
                   >
                     {post.frontmatter.title}
                   </a>


### PR DESCRIPTION
Introduce view transition names to blog titles for smoother transitions between blog list and individual posts. This enhances the user experience by providing a more seamless navigation flow.