### PR TITLE
Remove Toc component from zen-browser-april.md

### DIFF
--- a/src/pages/blog/zen-browser-april.md
+++ b/src/pages/blog/zen-browser-april.md
@@ -14,8 +14,6 @@ layout: "../../layouts/blog-post.astro"
 
 Zen Browser is _thrilled_ to announce... a switch to Chromium! We're promising faster speeds, better compatibility, and features galore!
 
-<Toc />
-
 ## Why Chromium?
 
 Chromium = performance, compatibility, and _innovation_. It's a _no-brainer_!


### PR DESCRIPTION
The Toc component was removed from the blog post as it was unnecessary and did not add value to the content. This change simplifies the layout and improves readability.