### PR TITLE
fix(hooks): keep branch validation on commit only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ pnpm-debug.log*
 # macOS-specific files
 .DS_Store
 
+# local agent context
+.context/
+
 # jetbrains setting folder
 .idea/
 

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -1,19 +1,23 @@
 pre-commit:
   parallel: true
-  exclude:
-    - public/**
-    - dist/**
-    - bun.lock
   commands:
     branch-validation:
       run: |
         bun run validate-branch
     quality:
+      exclude:
+        - public/**
+        - dist/**
+        - bun.lock
       glob: '*.{js,cjs,mjs,jsx,ts,cts,mts,tsx,d.ts,md,mdx,yaml,yml,json,html,css,astro}'
       run: |
         bun lefthook run quality
       stage_fixed: true
     cspell:
+      exclude:
+        - public/**
+        - dist/**
+        - bun.lock
       run: |
         bun cspell --gitignore {staged_files} .git/COMMIT_EDITMSG --no-must-find-files --no-progress --cache
 

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -5,6 +5,9 @@ pre-commit:
     - dist/**
     - bun.lock
   commands:
+    branch-validation:
+      run: |
+        bun run validate-branch
     quality:
       glob: '*.{js,cjs,mjs,jsx,ts,cts,mts,tsx,d.ts,md,mdx,yaml,yml,json,html,css,astro}'
       run: |
@@ -19,7 +22,7 @@ quality:
   commands:
     oxlint:
       priority: 1
-      glob: '*.{js,cjs,mjs,jsx,ts,cts,mts,tsx,d.ts,md,mdx,yaml,yml,json,html,css,astro}'
+      glob: '*.{js,cjs,mjs,jsx,ts,cts,mts,tsx,d.ts,astro}'
       run: |
         bun run lint {staged_files} --fix
       stage_fixed: true
@@ -47,16 +50,7 @@ post-merge:
 post-checkout:
   parallel: true
   commands:
-    branch-validation:
-      run: |
-        bun run validate-branch
     bun:
       files: git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD
       glob: '{package.json,bun.lock}'
       run: bun install
-
-pre-push:
-  commands:
-    branch-validation:
-      run: |
-        bun run validate-branch

--- a/src/scripts/README.md
+++ b/src/scripts/README.md
@@ -64,8 +64,7 @@ The following branches skip validation:
 
 Branch names are validated automatically on:
 
-- **Post-checkout** - When switching branches
-- **Pre-push** - Before pushing to remote
+- **Pre-commit** - Before creating a commit
 
 ## Manual Validation
 
@@ -87,8 +86,8 @@ git checkout -b chore/update-dependencies
 git checkout -b docs/api-documentation
 
 # Invalid branch names (will be rejected)
-git checkout -b feat-user-auth        # ❌ Use / not -
-git checkout -b 123-feat/header       # ❌ Can't start with number
-git checkout -b feature/header        # ❌ Use 'feat' not 'feature'
-git checkout -b feat/Header            # ❌ Scope must be lowercase
+git commit -m "feat: add auth"        # ❌ Fails on branch feat-user-auth
+git commit -m "feat: add header"      # ❌ Fails on branch 123-feat/header
+git commit -m "feat: add header"      # ❌ Fails on branch feature/header
+git commit -m "feat: add header"      # ❌ Fails on branch feat/Header
 ```


### PR DESCRIPTION
## Summary

- Move branch-name validation from checkout/push hooks to the pre-commit hook.
- Keep checkout limited to dependency installation when package files change.
- Ignore local `.context/` files and narrow the oxlint hook to lintable source files so docs/config-only commits can still pass hooks.

## Verification

- `bun run lint`
- `bun run format`
- `bun run spell`
- `bun run build`
