### PR TITLE
fix(branch): reject renovate type

### DIFF
--- a/src/scripts/validate-branch-name.js
+++ b/src/scripts/validate-branch-name.js
@@ -33,7 +33,6 @@ const CONVENTIONAL_TYPES = [
   'revert',
   'style',
   'test',
-  'renovate',
 ]
 
 const PROTECTED_BRANCHES = [


### PR DESCRIPTION
## What changed
- Removed `renovate` from the accepted branch type list in `src/scripts/validate-branch-name.js`.

## Why
- Keeps branch validation aligned with the conventional branch naming rule, so Renovate-related work uses supported types such as `chore/` instead of `renovate/`.

## Follow-up / test notes
- `bun run validate-branch`
- `bun run lint`
- `bun run build`
