### PR TITLE
chore(dependabot): document automatic rebasing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,10 @@ updates:
   - package-ecosystem: 'bun'
     directory: '/'
     schedule:
-      interval: 'weekly'
-      day: 'saturday'
+      interval: 'daily'
       time: '05:00'
       timezone: 'Pacific/Auckland'
+    rebase-strategy: 'auto'
     labels:
       - 'dependencies'
     assignees:
@@ -49,10 +49,10 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'weekly'
-      day: 'saturday'
+      interval: 'daily'
       time: '05:00'
       timezone: 'Pacific/Auckland'
+    rebase-strategy: 'auto'
     labels:
       - 'dependencies'
       - 'github-actions'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,8 @@ updates:
   - package-ecosystem: 'bun'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
+      day: 'saturday'
       time: '05:00'
       timezone: 'Pacific/Auckland'
     rebase-strategy: 'auto'
@@ -49,7 +50,8 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
+      day: 'saturday'
       time: '05:00'
       timezone: 'Pacific/Auckland'
     rebase-strategy: 'auto'


### PR DESCRIPTION
## Summary
- Keep Dependabot update checks on the existing weekly Saturday schedule.
- Add explicit `rebase-strategy: auto` for Bun and GitHub Actions updates.

## Why
- Documents that Dependabot automatic rebasing should stay enabled without increasing dependency update cadence.

## Verification
- `bun run validate-branch`
- `bun run format`
- `bun run lint`
- `bun run spell`
- `bun run build`

## Follow-up
- None.