### PR TITLE
chore(scripts): add clean script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "preview": "astro preview --port 3000",
     "start": "astro preview --port 3000",
     "astro": "astro",
+    "clean": "bun run scripts/clean.ts",
     "lint": "oxlint --type-aware",
     "lint:fix": "oxlint --type-aware --fix",
     "spell": "cspell \"**/*.{ts,tsx,js,jsx,astro,md,mdx,json,yml,yaml}\" --gitignore --cache --no-progress",

--- a/scripts/clean.ts
+++ b/scripts/clean.ts
@@ -1,0 +1,16 @@
+import { rm } from 'node:fs/promises'
+
+const targets = [
+  'node_modules',
+  'dist',
+  '.astro',
+  '.bun',
+  '.eslintcache',
+  '.cspellcache',
+]
+
+await Promise.all(
+  targets.map(target => rm(target, { force: true, recursive: true }))
+)
+
+process.stdout.write(`Cleaned ${targets.join(', ')}\n`)


### PR DESCRIPTION
## What changed
- Added a `clean` package script.
- Added `scripts/clean.ts` to remove generated and local cache directories.

## Why
- Provides a single command for resetting local install, build, and cache artifacts.

## Test notes
- `bun run build`
- `bun run format`
- `bun run lint`
- `bun run spell`

## Follow-up
- None.