### PR TITLE
chore(ci): setup Node for workflow

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -44,6 +44,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24.15.0
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:


### PR DESCRIPTION
## What changed
- Added `actions/setup-node` to the CI build job before Bun setup.
- Pinned the workflow Node version to `24.15.0`, matching the repository engine requirement.

## Why
- The build job installs production dependencies and runs Astro under CI, so it should use the same Node version required by the project.

## Follow-up / test notes
- Verified locally with `bun run format`, `bun run lint`, and `bun run build`.
- No follow-up work identified.