### PR TITLE
chore(dependabot): enable Bun beta ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,5 @@
 version: 2
+enable-beta-ecosystems: true
 
 updates:
   - package-ecosystem: 'bun'


### PR DESCRIPTION
## What changed
- Enabled Dependabot beta ecosystems so the existing `package-ecosystem: bun` configuration is accepted.

## Why
- Dependabot currently requires `enable-beta-ecosystems: true` for Bun ecosystem support.

## Follow-up / test notes
- No linked issue.
- Verified locally with `bun run format`, `bun run lint`, `bun run spell`, and `bun run build`.
- Push reported existing default-branch security alerts; this PR does not address those alerts.